### PR TITLE
Add GoogleCloudPlatform/k8s-cloud-provider to tide

### DIFF
--- a/prow/oss/config.yaml
+++ b/prow/oss/config.yaml
@@ -45,6 +45,7 @@ tide:
     - GoogleCloudPlatform/artifact-registry-yum-plugin
     - GoogleCloudPlatform/oss-test-infra
     - GoogleCloudPlatform/testgrid
+    - GoogleCloudPlatform/k8s-cloud-provider
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
* Add k8s-cloud-provider to config to enable tide